### PR TITLE
remove superfluous use of fully qualified function names using 'base::'

### DIFF
--- a/R/R/helpers.R
+++ b/R/R/helpers.R
@@ -49,7 +49,7 @@ getSrcOrDst<- function(path){
       path.and.file <- list("dir" = path, "file"= NULL)
     } else {
       # It's a file. Split the directory and the filename
-      path.and.file <- list("dir" = base::dirname(path), "file"= base::basename(path))
+      path.and.file <- list("dir" = dirname(path), "file"= basename(path))
     }
   }
   return(path.and.file)
@@ -70,13 +70,13 @@ browseDialog <- function(ans){
 
   # parse the dir path. don't keep the filename
   if (ans == "m" || is.null(ans)){
-    dir.path = base::dirname(path)
+    dir.path = dirname(path)
     one.file = NULL
   }
   # parse the dir path and the filename
   else if (ans == "s"){
-    dir.path = base::dirname(path)
-    one.file = base::basename(path)
+    dir.path = dirname(path)
+    one.file = basename(path)
   }
   out.list <- list("dir" = dir.path, "file"= one.file)
   return(out.list)
@@ -118,7 +118,7 @@ isNullOb <- function(x) is.null(x) | all(sapply(x, is.null))
 isDirectory <- function(s){
   # Get the basename (last item in file path), and check it for a file extension
   # If there is not a file extension (like below), then we can assume that it's a directory
-  if (tools::file_ext(base::basename(s)) == ""){
+  if (tools::file_ext(basename(s)) == ""){
     return(TRUE)
   }
   # No file extension. Assume it's a file and not a directory

--- a/R/R/time_series_filter.R
+++ b/R/R/time_series_filter.R
@@ -18,9 +18,9 @@ filterTs= function(ts, expression){
   } else {
     tryCatch({
       # Get the separate pieces of the expression
-      key = base::trimws(m[[1]][[2]])
-      op = base::trimws(m[[1]][[3]])
-      val = base::trimws(m[[1]][[4]])
+      key = trimws(m[[1]][[2]])
+      op = trimws(m[[1]][[3]])
+      val = trimws(m[[1]][[4]])
       # Attempt to cast value to numeric. If the result is NOT "NA", then keep it. Otherwise, it's not a numeric at all. 
       if (!is.na(as.numeric(val))){
         val = as.numeric(val)

--- a/R/R/time_series_query.R
+++ b/R/R/time_series_query.R
@@ -18,9 +18,9 @@ queryTs= function(ts, expression){
   } else {
     tryCatch({
       # Get the separate pieces of the expression
-      key = base::trimws(m[[1]][[2]])
-      op = base::trimws(m[[1]][[3]])
-      val = base::trimws(m[[1]][[4]])
+      key = trimws(m[[1]][[2]])
+      op = trimws(m[[1]][[3]])
+      val = trimws(m[[1]][[4]])
       # Attempt to cast value to numeric. If the result is NOT "NA", then keep it. Otherwise, it's not a numeric at all. 
       if (!is.na(as.numeric(val))){
         val = as.numeric(val)


### PR DESCRIPTION
It is odd to use a fully-qualified reference to function in the base namespace `base::`, especially when this is don't only rarely.

This PR removes the string `base::` R from the three `.R` files where it occurred.