### PR TITLE
The License field has a non-standard (for R) version of the GPL

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -8,7 +8,7 @@ Author: Christopher Heiser,
 Maintainer: Christopher Heiser <heiser@nau.edu>
 Description: Utilities to open, modify, analyze, and store LiPD data
 Depends: R (>= 3.1.0)
-License: GNU Public License
+License: GPL-2
 LazyData: TRUE
 RoxygenNote: 5.0.1
 URL: www.lipd.net


### PR DESCRIPTION
The `License` field in `DESCRIPTION` states the license is GPL (without version modifier, hence version 1) which is at odds with the `LICENSE` file in the repo base (which states GPL v2)

Also, the `License` field in `DESCRIPTION` gives the license in a non-standard (for R) way. Assuming that the license is GPL v2, this should be `License: GPL-2`.

This PR corrects the licence to GPL v2 and does so in a way that doesn't trouble `R CMD check`.